### PR TITLE
Fixed for Swift v4.1 MinGW

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ install:
   - SET "PATH_MINGW64=c:\msys64\mingw64\bin;c:\msys64\usr\bin"
   - SET PATH=%PATH_MINGW64%;%PATH_ORIGINAL%
   - SET MINGW64_DIR=c:/msys64/mingw64
-  - SET WORK_DIR=c:/projects
+  - SET WORK_DIR=c:\projects
   - cd %WORK_DIR%
   - SET PATH=%PATH%;%WORK_DIR%/Swift/usr/bin
  

--- a/wx/wx.swift
+++ b/wx/wx.swift
@@ -12,7 +12,7 @@ func bridge<T : AnyObject>(obj : T) -> VoidPtr {
 }
 
 func bridge<T : AnyObject>(ptr : VoidPtr) -> T {
-    return Unmanaged<T>.fromOpaque(ptr).takeUnretainedValue()
+    return Unmanaged<T>.fromOpaque(ptr!).takeUnretainedValue()
 }
 
 func bridgeRetained<T : AnyObject>(obj : T) -> VoidPtr {
@@ -20,7 +20,7 @@ func bridgeRetained<T : AnyObject>(obj : T) -> VoidPtr {
 }
 
 func bridgeTransfer<T : AnyObject>(ptr : VoidPtr) -> T {
-    return Unmanaged<T>.fromOpaque(ptr).takeRetainedValue()
+    return Unmanaged<T>.fromOpaque(ptr!).takeRetainedValue()
 }
 
 class ClosureData {
@@ -119,7 +119,7 @@ public class TopLevelWindow : Window {
 public class Frame : TopLevelWindow {
   public init(_ parent: Int?, _ id: Int32, _ title: String, size: Size = wx.Size(-1, -1), style: Int32 = DEFAULT_FRAME_STYLE) {
     super.init()
-    _obj = _wxc_Frame_Create(nil, id, _wxc_String_CreateUTF8(title), -1, -1, size.width, size.height, DEFAULT_FRAME_STYLE)
+    _obj = _wxc_Frame_Create(nil, id, _wxc_String_CreateUTF8(title), -1, -1, size.width, size.height, style)
   }
 }
 
@@ -200,7 +200,7 @@ public class FileDialog : Dialog {
   public func getPath() -> String {
     let wx_string = _wxc_FileDialog_GetPath(_obj)
     let utf8_char_buf = _wxc_wxString_GetUtf8(wx_string)
-    let ret = String(cString: _wxc_wxCharBuffer_DataUtf8(utf8_char_buf))
+    let ret = String(cString: _wxc_wxCharBuffer_DataUtf8(utf8_char_buf)!)
     _wxc_wxCharBuffer_Delete(utf8_char_buf)
     return ret
   }
@@ -289,7 +289,7 @@ public func execute(_ command: String, _ flags: Int32, _ callback: VoidPtr) -> I
 public func executeOutErr(_ command: String) -> String {
   let wx_string = _wxc_ExecuteOutErr(_wxc_String_CreateUTF8(command));
   let utf8_char_buf = _wxc_wxString_GetUtf8(wx_string)
-  let ret = String(cString: _wxc_wxCharBuffer_DataUtf8(utf8_char_buf))
+  let ret = String(cString: _wxc_wxCharBuffer_DataUtf8(utf8_char_buf)!)
   _wxc_wxCharBuffer_Delete(utf8_char_buf)
   return ret
 }

--- a/wx/wx_const.swift
+++ b/wx/wx_const.swift
@@ -16,6 +16,9 @@ public var MAXIMIZE_BOX: Int32 = 0x0200
 public var TINY_CAPTION: Int32 = 0x0080  // clashes with wxNO_DEFAULT
 public var RESIZE_BORDER: Int32 = 0x0040  // == wxCLOSE
 
+// frame
+public var FRAME_FLOAT_ON_PARENT : Int32 = 0x00000008
+
 // style
 public var BORDER_DEFAULT: Int32 = 0
 public var BORDER_NONE   : Int32 = 0x00200000

--- a/wx/wxc_wrapper.swift
+++ b/wx/wxc_wrapper.swift
@@ -1,8 +1,8 @@
 
-public typealias VoidPtr = UnsafeMutableRawPointer!
-public typealias WCharPtrPtr = UnsafeMutablePointer<UnsafeMutablePointer<UInt16>?>!
-public typealias ConstCharPtr = UnsafePointer<Int8>!
-public typealias CharPtr = UnsafeMutablePointer<Int8>!
+public typealias VoidPtr = UnsafeMutableRawPointer?
+public typealias WCharPtrPtr = UnsafeMutablePointer<UnsafeMutablePointer<UInt16>?>?
+public typealias ConstCharPtr = UnsafePointer<Int8>?
+public typealias CharPtr = UnsafeMutablePointer<Int8>?
 
 // typedef void (*ClosureFun)( void* _fun, void* _data, void* _evt );
 public typealias ClosureFun = @convention(c) (VoidPtr, VoidPtr, VoidPtr) -> Void

--- a/wxc/src/CMakeLists.txt
+++ b/wxc/src/CMakeLists.txt
@@ -1,15 +1,17 @@
 cmake_minimum_required(VERSION 2.8.12)
 
-SET(CMAKE_C_COMPILER clang)
-SET(CMAKE_CXX_COMPILER clang++)
-SET(COMMON_FLAGS "-std=c++14 -DWXUSINGDLL -DSTATIC_WXC -DCALLINGCONV=__attribute__((swiftcall)) -O2 -Wno-ignored-attributes -Wno-macro-redefined -D__GXX_ABI_VERSION=1008")
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    SET(CMAKE_C_COMPILER clang)
+    SET(CMAKE_CXX_COMPILER clang++)
+endif()
+SET(COMMON_FLAGS "-std=c++14 -DWXUSINGDLL -DSTATIC_WXC -DCALLINGCONV=__attribute__((swiftcall)) -O2 -Wno-ignored-attributes -Wno-macro-redefined -D__GXX_ABI_VERSION=1011")
 
 # Compile Flags
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMMON_FLAGS}")
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COMMON_FLAGS}")
 
 include_directories(
-    "${WXWIDGETS_DIR}/lib/gcc510TDM_x64_dll/mswu"
+    "${WXWIDGETS_DIR}/lib/gcc720_x64_dll/mswu"
     "${WXWIDGETS_DIR}/include"
      ${PROJECT_SOURCE_DIR}/include
     )


### PR DESCRIPTION
- Changed wxWidgets version 3.0.4 gcc720
- Removed deprecated feature ! in UnsafeMutablePointer<>!
- Should be used with clang version 5.0.2 or later (not work with clang 5.0.1)